### PR TITLE
Improve detection using package names

### DIFF
--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/BannedApps.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/BannedApps.kt
@@ -1,64 +1,160 @@
 package com.hariomahlawat.bannedappdetector
 
+/**
+ * List of monitored apps with their known package names.
+ * Package names are best effort and may not cover all variants.
+ */
 val bannedAppsList = listOf(
     // A
-    "AliExpress", "AliPay", "APUS Browser", "APUS Launcher", "Azar",
+    MonitoredAppMeta("com.alibaba.aliexpress", "AliExpress"),
+    MonitoredAppMeta("com.eg.android.AlipayGphone", "AliPay"),
+    MonitoredAppMeta("com.apusapps.browser", "APUS Browser"),
+    MonitoredAppMeta("com.apusapps.launcher", "APUS Launcher"),
+    MonitoredAppMeta("com.azarlive.android", "Azar"),
     // B
-    "Baidu Map", "Baidu Translate", "Badoo", "Banggood", "BeautyPlus", "BeautyPlus Me",
-    "BeautyCam", "Bigo Live", "Likee", "Vigo Video", "Bumble",
+    MonitoredAppMeta("com.baidu.BaiduMap", "Baidu Map"),
+    MonitoredAppMeta("com.baidu.translate", "Baidu Translate"),
+    MonitoredAppMeta("com.badoo.mobile", "Badoo"),
+    MonitoredAppMeta("com.banggood.client", "Banggood"),
+    MonitoredAppMeta("com.commsource.beautyplus", "BeautyPlus"),
+    MonitoredAppMeta("com.meitu.beautyplusme", "BeautyPlus Me"),
+    MonitoredAppMeta("com.meitu.beautycamera", "BeautyCam"),
+    MonitoredAppMeta("sg.bigo.live", "Bigo Live"),
+    MonitoredAppMeta("video.like", "Likee"),
+    MonitoredAppMeta("com.bumble.app", "Bumble"),
     // C
-    "CamScanner", "CamScanner HD", "CamScanner Lite", "Club Factory",
-    "Clean Master", "CM Browser", "CM Security", "CM Lite", "Coffee Meets Bagel",
-    "Couchsurfing", "Clash of Kings",
+    MonitoredAppMeta("com.intsig.camscanner", "CamScanner"),
+    MonitoredAppMeta("com.intsig.camscannerhd", "CamScanner HD"),
+    MonitoredAppMeta("com.intsig.camscannerlite", "CamScanner Lite"),
+    MonitoredAppMeta("com.clubfactory.app", "Club Factory"),
+    MonitoredAppMeta("com.cleanmaster.mguard", "Clean Master"),
+    MonitoredAppMeta("com.ksmobile.cb", "CM Browser"),
+    MonitoredAppMeta("com.cleanmaster.security", "CM Security"),
+    MonitoredAppMeta("com.cmcm.lite", "CM Lite"),
+    MonitoredAppMeta("com.coffeemeetsbagel", "Coffee Meets Bagel"),
+    MonitoredAppMeta("com.couchsurfing.mobile.android", "Couchsurfing"),
+    MonitoredAppMeta("com.elex.cok.gp", "Clash of Kings"),
     // D
-    "Dailyhunt", "DU Battery Saver", "DU Cleaner", "DU Recorder", "DU Privacy", "DU Browser",
+    MonitoredAppMeta("in.dailyhunt", "Dailyhunt"),
+    MonitoredAppMeta("com.dianxinos.dxbs", "DU Battery Saver"),
+    MonitoredAppMeta("com.duapps.cleaner", "DU Cleaner"),
+    MonitoredAppMeta("com.duapps.recorder", "DU Recorder"),
+    MonitoredAppMeta("com.duapps.applock", "DU Privacy"),
+    MonitoredAppMeta("com.duapps.browser", "DU Browser"),
     // E
-    "Ello", "ES File Explorer",
+    MonitoredAppMeta("co.ello.Ello", "Ello"),
+    MonitoredAppMeta("com.estrongs.android.pop", "ES File Explorer"),
     // F
-    "Facebook", "Facebook Lite", "Messenger", "Pages Manager", "Meta Ads Manager",
-    "FriendsFeed",
+    MonitoredAppMeta("com.facebook.katana", "Facebook"),
+    MonitoredAppMeta("com.facebook.lite", "Facebook Lite"),
+    MonitoredAppMeta("com.facebook.orca", "Messenger"),
+    MonitoredAppMeta("com.facebook.pages.app", "Pages Manager"),
+    MonitoredAppMeta("com.facebook.adsmanager", "Meta Ads Manager"),
+    MonitoredAppMeta("com.friendsfeed", "FriendsFeed"),
     // G
-    "Gearbest",
+    MonitoredAppMeta("com.globalegrow.app.gearbest", "Gearbest"),
     // H
-    "Happn", "Helo", "Hike", "Hinge", "Hungama Music",
+    MonitoredAppMeta("com.ftw_and_co.happn", "Happn"),
+    MonitoredAppMeta("in.helloapp", "Helo"),
+    MonitoredAppMeta("com.bsb.hike", "Hike"),
+    MonitoredAppMeta("co.hinge.app", "Hinge"),
+    MonitoredAppMeta("com.hungama.myplay.activity", "Hungama Music"),
     // I
-    "IMO", "Instagram", "Threads", "Layout", "Boomerang",
+    MonitoredAppMeta("com.imo.android.imoim", "IMO"),
+    MonitoredAppMeta("com.instagram.android", "Instagram"),
+    MonitoredAppMeta("com.instagram.barcelona", "Threads"),
+    MonitoredAppMeta("com.instagram.layout", "Layout"),
+    MonitoredAppMeta("com.instagram.boomerang", "Boomerang"),
     // K
-    "Kwai",
+    MonitoredAppMeta("com.kwai.video", "Kwai"),
     // L
-    "Line", "LiveMe",
+    MonitoredAppMeta("jp.naver.line.android", "Line"),
+    MonitoredAppMeta("com.cmcm.live", "LiveMe"),
     // M
-    "Mi Store", "Mi Community", "Mi Video Call", "Mi Browser", "GetApps",
-    "Modlily",
+    MonitoredAppMeta("com.mi.global.shop", "Mi Store"),
+    MonitoredAppMeta("com.mi.global.bbs", "Mi Community"),
+    MonitoredAppMeta("com.xiaomi.mivideocall", "Mi Video Call"),
+    MonitoredAppMeta("com.mi.globalbrowser", "Mi Browser"),
+    MonitoredAppMeta("com.xiaomi.mipicks", "GetApps"),
+    MonitoredAppMeta("com.modlily.android", "Modlily"),
     // N
-    "Nimbuzz", "NONO Live", "NewsDog",
+    MonitoredAppMeta("com.nimbuzz", "Nimbuzz"),
+    MonitoredAppMeta("com.nono.android", "NONO Live"),
+    MonitoredAppMeta("com.newsdog", "NewsDog"),
     // O
-    "OkCupid",
+    MonitoredAppMeta("com.okcupid.app", "OkCupid"),
     // P
-    "Parallel Space", "POPxo", "Pratilipi", "PUBG Mobile", "PUBG Mobile Lite",
-    "PUBG NEW STATE", "Arena Breakout", "Call of Duty Mobile",
+    MonitoredAppMeta("com.lbe.parallel.intl", "Parallel Space"),
+    MonitoredAppMeta("com.popxo", "POPxo"),
+    MonitoredAppMeta("com.pratilipi.mobile", "Pratilipi"),
+    MonitoredAppMeta("com.tencent.ig", "PUBG Mobile"),
+    MonitoredAppMeta("com.tencent.iglite", "PUBG Mobile Lite"),
+    MonitoredAppMeta("com.pubg.newstate", "PUBG NEW STATE"),
+    MonitoredAppMeta("com.tencent.arenabreakout", "Arena Breakout"),
+    MonitoredAppMeta("com.activision.callofduty.shooter", "Call of Duty Mobile"),
     // Q
-    "QQ", "QQ Music", "QQ Mail", "QQ Player", "QQ Browser", "WeSync", "Qzone",
+    MonitoredAppMeta("com.tencent.mobileqq", "QQ"),
+    MonitoredAppMeta("com.tencent.qqmusic", "QQ Music"),
+    MonitoredAppMeta("com.tencent.qqmail", "QQ Mail"),
+    MonitoredAppMeta("com.tencent.qqlive", "QQ Player"),
+    MonitoredAppMeta("com.tencent.mtt", "QQ Browser"),
+    MonitoredAppMeta("com.tencent.wesync", "WeSync"),
+    MonitoredAppMeta("com.qzone", "Qzone"),
     // R
-    "Reddit", "Romwe", "Rosegal",
+    MonitoredAppMeta("com.reddit.frontpage", "Reddit"),
+    MonitoredAppMeta("com.romwe", "Romwe"),
+    MonitoredAppMeta("com.rosegal", "Rosegal"),
     // S
-    "SHAREit", "SHAREit Lite", "Shein", "Snow", "Snapchat", "Songs.pk", "SoundHound",
+    MonitoredAppMeta("com.lenovo.anyshare.gps", "SHAREit"),
+    MonitoredAppMeta("shareit.lite", "SHAREit Lite"),
+    MonitoredAppMeta("com.zzkko", "Shein"),
+    MonitoredAppMeta("com.campmobile.snow", "Snow"),
+    MonitoredAppMeta("com.snapchat.android", "Snapchat"),
+    MonitoredAppMeta("com.songspk.app", "Songs.pk"),
+    MonitoredAppMeta("com.melodis.midomiMusicIdentifier.freemium", "SoundHound"),
     // T
-    "TikTok", "TikTok Lite", "CapCut", "Lemon8", "Tantan", "ToTok", "Truecaller",
-    "Truecaller Lite", "Tumblr", "Tinder", "Tinder Lite", "TrulyMadly",
+    MonitoredAppMeta("com.zhiliaoapp.musically", "TikTok"),
+    MonitoredAppMeta("com.zhiliaoapp.musically.go", "TikTok Lite"),
+    MonitoredAppMeta("com.lemon.lvoverseas", "CapCut"),
+    MonitoredAppMeta("com.lemon.lvoverseas.lite", "Lemon8"),
+    MonitoredAppMeta("com.p1.mobile.putong", "Tantan"),
+    MonitoredAppMeta("com.tatteam.totalk", "ToTok"),
+    MonitoredAppMeta("com.truecaller", "Truecaller"),
+    MonitoredAppMeta("com.truecaller.lite", "Truecaller Lite"),
+    MonitoredAppMeta("com.tumblr", "Tumblr"),
+    MonitoredAppMeta("com.tinder", "Tinder"),
+    MonitoredAppMeta("com.tinder.lite", "Tinder Lite"),
+    MonitoredAppMeta("com.trulymadly.android.app", "TrulyMadly"),
     // U
-    "UC Browser", "UC Browser Mini", "UC Turbo", "UC News", "Uplive",
+    MonitoredAppMeta("com.UCMobile.intl", "UC Browser"),
+    MonitoredAppMeta("com.uc.browser.en", "UC Browser Mini"),
+    MonitoredAppMeta("com.ucturbo", "UC Turbo"),
+    MonitoredAppMeta("com.uc.iflow", "UC News"),
+    MonitoredAppMeta("com.asiainno.uplive", "Uplive"),
     // V
-    "Viber", "Vigo Video", "Vimo", "Vmate", "VivaVideo", "VivaVideo Editor",
-    "Vokal", "Vault-Hide",
+    MonitoredAppMeta("com.viber.voip", "Viber"),
+    MonitoredAppMeta("com.vimo.videoeditor", "Vimo"),
+    MonitoredAppMeta("com.nebula.vigo", "Vigo Video"),
+    MonitoredAppMeta("com.vmate", "Vmate"),
+    MonitoredAppMeta("com.quvideo.xiaoying", "VivaVideo"),
+    MonitoredAppMeta("com.quvideo.xiaoying.pro", "VivaVideo Editor"),
+    MonitoredAppMeta("app.vokal.india", "Vokal"),
+    MonitoredAppMeta("com.netqin.ps", "Vault-Hide"),
     // W
-    "WeChat", "WeChat Work", "WeChat Lite", "Weibo", "Wonder Camera", "PhotoWonder", "Woo",
+    MonitoredAppMeta("com.tencent.mm", "WeChat"),
+    MonitoredAppMeta("com.tencent.wework", "WeChat Work"),
+    MonitoredAppMeta("com.tencent.mm.small", "WeChat Lite"),
+    MonitoredAppMeta("com.sina.weibo", "Weibo"),
+    MonitoredAppMeta("com.baidu.wondercamera", "Wonder Camera"),
+    MonitoredAppMeta("cn.jingling.motu.photowonder", "PhotoWonder"),
+    MonitoredAppMeta("com.doubleyou.w", "Woo"),
     // X
-    "Xender",
+    MonitoredAppMeta("cn.xender", "Xender"),
     // Y
-    "Yelp",
+    MonitoredAppMeta("com.yelp.android", "Yelp"),
     // Z
-    "Zoom"
+    MonitoredAppMeta("us.zoom.videomeetings", "Zoom")
 )
 
-val bannedAppsAZ: Map<Char, List<String>> = bannedAppsList.groupBy { it.first().uppercaseChar() }
+val bannedAppsAZ: Map<Char, List<String>> =
+    bannedAppsList.map { it.displayName }.groupBy { it.first().uppercaseChar() }

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/monitored/MonitoredAppsRepositoryImpl.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/monitored/MonitoredAppsRepositoryImpl.kt
@@ -9,9 +9,5 @@ import javax.inject.Singleton
 
 @Singleton
 class MonitoredAppsRepositoryImpl @Inject constructor() : MonitoredAppsRepository {
-    private val baseList = bannedAppsList.map { name ->
-        MonitoredAppMeta(name, name)
-    }
-
-    override fun getMonitoredApps(): List<MonitoredAppMeta> = baseList
+    override fun getMonitoredApps(): List<MonitoredAppMeta> = bannedAppsList
 }

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/usecase/UseCases.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/usecase/UseCases.kt
@@ -30,17 +30,15 @@ class ScanMonitoredAppsUseCase(
 
         /* 1. Capture (PackageInfo, ApplicationInfo?) pairs --------------- */
         val installed: List<Pair<PackageInfo, ApplicationInfo?>> =
-            pm.getInstalledPackages(0) /* API‑33+: use flagsOf(0L) */       // :contentReference[oaicite:0]{index=0}
-                .map { pkg -> pkg to pkg.applicationInfo }                  // nullable by design :contentReference[oaicite:1]{index=1}
+            pm.getInstalledPackages(0) /* API‑33+: use flagsOf(0L) */
+                .map { pkg -> pkg to pkg.applicationInfo }                  // nullable by design
 
         /* 2. Build result list ------------------------------------------- */
         val results = monitoredAppsRepository.getMonitoredApps().map { meta ->
 
-            /* find first installed app whose *label* matches displayName */
-            val match = installed.find { (_, info) ->
-                info != null &&                                           // guard nullability :contentReference[oaicite:2]{index=2}
-                        pm.getApplicationLabel(info).toString()
-                            .equals(meta.displayName, ignoreCase = true)
+            /* find first installed app whose package name matches */
+            val match = installed.find { (pkgInfo, _) ->
+                pkgInfo.packageName.equals(meta.packageName, ignoreCase = true)
             }
 
             if (match != null) {


### PR DESCRIPTION
## Summary
- store monitored apps with package names
- remove the duplicate Vigo Video entry
- look up installed packages by name instead of label

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687e7da817d48329b82c9dc96ed66749