### PR TITLE
Improve light mode polish with dynamic colors

### DIFF
--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/BannedAppsScreen.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/BannedAppsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -29,6 +30,7 @@ import androidx.compose.ui.unit.sp
 import com.hariomahlawat.bannedappdetector.ui.theme.BgGradientEnd
 import com.hariomahlawat.bannedappdetector.ui.theme.BgGradientStart
 import com.hariomahlawat.bannedappdetector.ui.theme.BrandGold
+import com.hariomahlawat.bannedappdetector.util.setSystemBars
 import kotlinx.coroutines.launch
 import com.hariomahlawat.bannedappdetector.bannedAppsAZ
 
@@ -41,8 +43,16 @@ fun BannedAppsScreen(
     val searchQuery = remember { mutableStateOf("") }
     val listState   = rememberLazyListState()
     val scope       = rememberCoroutineScope()
+    val dark = isSystemInDarkTheme()
+    setSystemBars(
+        color = if (dark) Color.Transparent else MaterialTheme.colorScheme.surfaceVariant,
+        darkIcons = !dark
+    )
 
     Scaffold(
+        modifier = Modifier
+            .statusBarsPadding()
+            .navigationBarsPadding(),
         topBar = {
             TopAppBar(
                 title = { Text("Army Banned Apps") },
@@ -72,7 +82,17 @@ fun BannedAppsScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Brush.verticalGradient(listOf(BgGradientStart, BgGradientEnd)))
+                .background(
+                    Brush.verticalGradient(
+                        if (dark)
+                            listOf(BgGradientStart, BgGradientEnd)
+                        else
+                            listOf(
+                                MaterialTheme.colorScheme.surface,
+                                MaterialTheme.colorScheme.surfaceVariant
+                            )
+                    )
+                )
                 .padding(padding)
         ) {
 

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/HomeScreen.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/HomeScreen.kt
@@ -23,9 +23,12 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.ElevatedAssistChip
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,6 +45,7 @@ import com.hariomahlawat.bannedappdetector.ui.theme.BgGradientStart
 import com.hariomahlawat.bannedappdetector.ui.theme.BrandGold
 import com.hariomahlawat.bannedappdetector.ui.theme.SuccessGreen
 import com.hariomahlawat.bannedappdetector.ui.theme.glassCard
+import com.hariomahlawat.bannedappdetector.util.setSystemBars
 import java.text.DateFormat
 import java.util.Date
 
@@ -54,8 +58,16 @@ fun HomeScreen(
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsState()
+    val dark = isSystemInDarkTheme()
+    setSystemBars(
+        color = if (dark) Color.Transparent else MaterialTheme.colorScheme.surfaceVariant,
+        darkIcons = !dark
+    )
 
     Scaffold(
+        modifier = Modifier
+            .statusBarsPadding()
+            .navigationBarsPadding(),
         topBar = {
             CenterAlignedTopAppBar(                    // Material3 app‑bar
                 title = { Text("Banned App Detector") },
@@ -92,15 +104,22 @@ private fun HomeContent(
         modifier = modifier
             .fillMaxSize()
             .background(
-                Brush.verticalGradient(listOf(BgGradientStart, BgGradientEnd))
+                Brush.verticalGradient(
+                    if (dark)
+                        listOf(BgGradientStart, BgGradientEnd)
+                    else
+                        listOf(
+                            MaterialTheme.colorScheme.surface,
+                            MaterialTheme.colorScheme.surfaceVariant
+                        )
+                )
             )
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
-                .padding(horizontal = 20.dp, vertical = 24.dp)
-                .navigationBarsPadding(),
+                .padding(horizontal = 20.dp, vertical = 24.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
 
@@ -134,7 +153,7 @@ private fun HomeContent(
                 modifier  = Modifier.padding(top = 4.dp, bottom = 12.dp)
             )
 
-            AssistChip(
+            ElevatedAssistChip(
                 onClick = onViewBannedApps,
                 label = { Text("Browse Army Banned Apps") },
                 leadingIcon = { Icon(Icons.Default.ArrowForward, contentDescription = null) }
@@ -149,8 +168,9 @@ private fun HomeContent(
             Button(
                 onClick = onScan,
                 enabled = !state.isScanning,                     // avoid double‑tap
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
                 modifier = Modifier
-                    .fillMaxWidth(0.7f)
+                    .fillMaxWidth(0.8f)
                     .height(56.dp)
             ) {
                 if (state.isScanning) {
@@ -185,7 +205,10 @@ private fun HomeContent(
 /* ---------- 3. Trust chips ---------- */
 @Composable
 private fun TrustChipsRow() {
-    val chipBg = Color.White.copy(alpha = 0.24f)
+    val chipBg = if (isSystemInDarkTheme())
+        Color.White.copy(alpha = 0.24f)
+    else
+        MaterialTheme.colorScheme.surfaceVariant
     val chipModifier = Modifier
         .padding(horizontal = 4.dp)
         .clip(RoundedCornerShape(50))

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/MainActivity.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/MainActivity.kt
@@ -3,6 +3,8 @@ package com.hariomahlawat.bannedappdetector
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.core.view.WindowCompat
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -14,6 +16,8 @@ import com.hariomahlawat.bannedappdetector.ui.theme.BannedAppDetectorTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             BannedAppDetectorTheme {
                 AppNavigation()

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/ResultsScreen.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/ResultsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,6 +31,7 @@ import com.hariomahlawat.bannedappdetector.util.DeviceInfo
 import com.hariomahlawat.bannedappdetector.util.getDeviceInfo
 import com.hariomahlawat.bannedappdetector.util.saveToCache
 import com.hariomahlawat.bannedappdetector.util.shareImage
+import com.hariomahlawat.bannedappdetector.util.setSystemBars
 import java.text.DateFormat
 import java.util.*
 
@@ -45,8 +47,16 @@ fun ResultsScreen(
     val context = LocalContext.current
     val view    = LocalView.current
     val device  = getDeviceInfo(context)
+    val dark = isSystemInDarkTheme()
+    setSystemBars(
+        color = if (dark) Color.Transparent else MaterialTheme.colorScheme.surfaceVariant,
+        darkIcons = !dark
+    )
 
     Scaffold(
+        modifier = Modifier
+            .statusBarsPadding()
+            .navigationBarsPadding(),
         topBar = {
             TopAppBar(
                 title = { Text("Scan Results", style = MaterialTheme.typography.headlineSmall) },
@@ -81,7 +91,17 @@ fun ResultsScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Brush.verticalGradient(listOf(BgGradientStart, BgGradientEnd)))
+                .background(
+                    Brush.verticalGradient(
+                        if (dark)
+                            listOf(BgGradientStart, BgGradientEnd)
+                        else
+                            listOf(
+                                MaterialTheme.colorScheme.surface,
+                                MaterialTheme.colorScheme.surfaceVariant
+                            )
+                    )
+                )
         ) {
             ResultsBody(
                 state          = state,

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/ui/theme/Theme.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/ui/theme/Theme.kt
@@ -1,46 +1,26 @@
 package com.hariomahlawat.bannedappdetector.ui.theme
 
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.foundation.isSystemInDarkTheme
 import com.hariomahlawat.bannedappdetector.ui.theme.AppTypography
-import com.hariomahlawat.bannedappdetector.ui.theme.ArcGlow
-import com.hariomahlawat.bannedappdetector.ui.theme.BgGradientEnd
 import com.hariomahlawat.bannedappdetector.ui.theme.BgGradientStart
 import com.hariomahlawat.bannedappdetector.ui.theme.BrandGold
-import com.hariomahlawat.bannedappdetector.ui.theme.BrandGoldAlt
-import com.hariomahlawat.bannedappdetector.ui.theme.NeutralGrey
-import com.hariomahlawat.bannedappdetector.ui.theme.SuccessGreen
-import com.hariomahlawat.bannedappdetector.ui.theme.WarningYellow
-
-private val DarkColorScheme = darkColorScheme(
-    primary = BrandGold,
-    secondary = BrandGoldAlt,
-    tertiary = WarningYellow,
-    background = BgGradientStart,
-    surface = BgGradientEnd,
-    onPrimary = BgGradientStart,
-    onBackground = BrandGoldAlt
-)
-
-private val LightColorScheme = lightColorScheme(
-    primary = BrandGold,
-    secondary = BrandGoldAlt,
-    tertiary = WarningYellow,
-    background = Color(0xFFF8F9FA),
-    surface = Color(0xFFFFFFFF),
-    onPrimary = Color.Black,
-    onBackground = Color.Black
-)
-
 @Composable
 fun BannedAppDetectorTheme(
-    darkTheme: Boolean = true,
+    darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+    val context = LocalContext.current
+    val dynamic = if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+    val colorScheme = dynamic.copy(
+        primary = BrandGold,
+        onPrimary = if (darkTheme) BgGradientStart else Color.Black
+    )
 
     MaterialTheme(
         colorScheme = colorScheme,

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/util/SystemBars.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/util/SystemBars.kt
@@ -1,0 +1,25 @@
+package com.hariomahlawat.bannedappdetector.util
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowInsetsControllerCompat
+
+@Composable
+fun setSystemBars(color: Color, darkIcons: Boolean) {
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        val window = (view.context as Activity).window
+        SideEffect {
+            window.statusBarColor = color.toArgb()
+            window.navigationBarColor = color.toArgb()
+            WindowInsetsControllerCompat(window, view).let { controller ->
+                controller.isAppearanceLightStatusBars = darkIcons
+                controller.isAppearanceLightNavigationBars = darkIcons
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- apply dynamic light/dark schemes in `BannedAppDetectorTheme`
- draw edge-to-edge and tint system bars with `setSystemBars`
- style Home screen with adaptive gradient, ElevatedAssistChip, and wider button
- extend edge-to-edge and dynamic gradients to other screens

## Testing
- `./gradlew assembleDebug` *(fails: unable to download Gradle due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687ef5f64c708329b488db3cc9a8d62b