### PR TITLE
Add footer with version info

### DIFF
--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/HomeScreen.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.hariomahlawat.bannedappdetector
 
 import com.hariomahlawat.bannedappdetector.components.ScanProgressBar
+import com.hariomahlawat.bannedappdetector.components.AppInfoFooter
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -201,6 +202,12 @@ private fun HomeContent(
 
             Spacer(Modifier.height(40.dp))
         }
+
+        AppInfoFooter(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 12.dp)
+        )
     }
 }
 

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/components/AppInfoFooter.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/components/AppInfoFooter.kt
@@ -1,0 +1,33 @@
+package com.hariomahlawat.bannedappdetector.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hariomahlawat.bannedappdetector.BuildConfig
+
+@Composable
+fun AppInfoFooter(modifier: Modifier = Modifier) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Text(
+            text = "v${BuildConfig.VERSION_NAME}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = "Developed by @hariomahlawat",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- show app version and credit info via a new `AppInfoFooter` composable
- place the footer at the bottom of `HomeScreen`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687f0591d07c8329b8172f3bf62dc125