### PR TITLE
Add simple Compose splash screen

### DIFF
--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/MainActivity.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/MainActivity.kt
@@ -29,7 +29,14 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun AppNavigation() {
     val navController = rememberNavController()
-    NavHost(navController, startDestination = "home") {
+    NavHost(navController, startDestination = "splash") {
+        composable("splash") {
+            SplashScreen {
+                navController.navigate("home") {
+                    popUpTo("splash") { inclusive = true }
+                }
+            }
+        }
         composable("home") {
             HomeScreen(
                 onViewResults    = { navController.navigate("results") },

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/SplashScreen.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/SplashScreen.kt
@@ -1,0 +1,36 @@
+package com.hariomahlawat.bannedappdetector
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+@Composable
+fun SplashScreen(onTimeout: () -> Unit) {
+    LaunchedEffect(Unit) {
+        delay(1000)
+        onTimeout()
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.primary),
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            painter = painterResource(R.drawable.archer_logo),
+            contentDescription = "App logo – archer",
+            modifier = Modifier.size(192.dp)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a Compose-based splash screen that shows the archer logo for a second
- update navigation to start at the new splash route

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687f12b8234083299b93c1563fbfbb3d