### PR TITLE
Improve splash transition with grid animation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation(libs.hilt.android)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.media3.common.ktx)
+    implementation(libs.androidx.core.splashscreen)
     kapt(libs.hilt.compiler)
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.datastore.preferences)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.BannedAppDetector">
+            android:theme="@style/Theme.BannedAppDetector.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/MainActivity.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/MainActivity.kt
@@ -1,20 +1,29 @@
 package com.hariomahlawat.bannedappdetector
 
+import android.animation.AnimatorSet
+import android.animation.ObjectAnimator
 import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.core.animation.doOnEnd
 import dagger.hilt.android.AndroidEntryPoint
 import com.hariomahlawat.bannedappdetector.ui.theme.BannedAppDetectorTheme
+import com.hariomahlawat.bannedappdetector.SecurityGridView
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        val splash = installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -23,20 +32,47 @@ class MainActivity : ComponentActivity() {
                 AppNavigation()
             }
         }
+        val content = findViewById<View>(android.R.id.content)
+        content.alpha = 0f
+
+        splash.setOnExitAnimationListener { provider ->
+            val parent = provider.view.parent as ViewGroup
+            val grid = SecurityGridView(this).apply {
+                layoutParams = FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+            }
+            parent.addView(grid)
+
+            val width = provider.view.width.toFloat()
+            val slide = ObjectAnimator.ofFloat(grid, View.TRANSLATION_X, -width, width).apply {
+                duration = 250
+            }
+            val fadeOut = ObjectAnimator.ofFloat(grid, View.ALPHA, grid.alpha, 0f).apply {
+                startDelay = 250
+                duration = 150
+            }
+            val contentFade = ObjectAnimator.ofFloat(content, View.ALPHA, 0f, 1f).apply {
+                startDelay = 250
+                duration = 150
+            }
+            AnimatorSet().apply {
+                playTogether(slide, fadeOut, contentFade)
+                doOnEnd {
+                    parent.removeView(grid)
+                    provider.remove()
+                }
+                start()
+            }
+        }
     }
 }
 
 @Composable
 fun AppNavigation() {
     val navController = rememberNavController()
-    NavHost(navController, startDestination = "splash") {
-        composable("splash") {
-            SplashScreen {
-                navController.navigate("home") {
-                    popUpTo("splash") { inclusive = true }
-                }
-            }
-        }
+    NavHost(navController, startDestination = "home") {
         composable("home") {
             HomeScreen(
                 onViewResults    = { navController.navigate("results") },

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/SecurityGridView.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/SecurityGridView.kt
@@ -1,0 +1,48 @@
+package com.hariomahlawat.bannedappdetector
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.View
+
+class SecurityGridView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        color = 0xFFFFFFFF.toInt()
+        strokeWidth = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            2f,
+            resources.displayMetrics
+        )
+        alpha = (255 * 0.02f).toInt()
+    }
+
+    private val step = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP,
+        32f,
+        resources.displayMetrics
+    )
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        val w = width.toFloat()
+        val h = height.toFloat()
+        var start = -h
+        while (start < w) {
+            canvas.drawLine(start, h, start + h, 0f, paint)
+            start += step
+        }
+        start = -h
+        while (start < w) {
+            canvas.drawLine(start, 0f, start + h, h, paint)
+            start += step
+        }
+    }
+}

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,4 +3,10 @@
         <item name="android:statusBarColor">?attr/colorSurfaceVariant</item>
         <item name="android:navigationBarColor">?attr/colorSurface</item>
     </style>
+
+    <style name="Theme.BannedAppDetector.Splash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/black</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/archer_logo</item>
+        <item name="postSplashScreenTheme">@style/Theme.BannedAppDetector</item>
+    </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ junit = "4.13.2"
 androidJunit = "1.2.1"
 espresso = "3.6.1"
 media3CommonKtx = "1.7.1"
+coreSplash = "1.0.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -38,6 +39,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidJunit" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
 androidx-media3-common-ktx = { group = "androidx.media3", name = "media3-common-ktx", version.ref = "media3CommonKtx" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplash" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add `core-splashscreen` dependency
- customize launch theme to use the system splash
- hook `installSplashScreen` in `MainActivity`
- animate a subtle security grid overlay during exit
- fade in main content while grid slides away

## Testing
- `./gradlew help` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687f17b9d05c83299b76e633136d6fdb