### PR TITLE
Add theme switching via Compose

### DIFF
--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/HomeScreen.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/HomeScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.VerifiedUser
 import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
@@ -23,12 +25,12 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ElevatedAssistChip
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -55,10 +57,11 @@ import java.util.Date
 fun HomeScreen(
     onViewResults: () -> Unit,
     onViewBannedApps: () -> Unit,
+    onToggleTheme: () -> Unit,
+    dark: Boolean,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsState()
-    val dark = isSystemInDarkTheme()
     setSystemBars(
         color = if (dark) Color.Transparent else MaterialTheme.colorScheme.surfaceVariant,
         darkIcons = !dark
@@ -74,7 +77,13 @@ fun HomeScreen(
                 colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
                     containerColor = Color.Transparent,
                     titleContentColor = BrandGold
-                )
+                ),
+                actions = {
+                    IconButton(onClick = onToggleTheme) {
+                        val icon = if (dark) Icons.Default.LightMode else Icons.Default.DarkMode
+                        Icon(icon, contentDescription = "Toggle theme")
+                    }
+                }
             )
         },
         containerColor = Color.Transparent           // keep gradient visible
@@ -163,7 +172,7 @@ private fun HomeContent(
             Spacer(Modifier.height(32.dp))
 
             /* ---------- trust / privacy chips ---------- */
-            TrustChipsRow()
+            TrustChipsRow(dark)
             Spacer(Modifier.height(28.dp))
 
             /* scan button */
@@ -212,8 +221,8 @@ private fun HomeContent(
 
 /* ---------- 3. Trust chips ---------- */
 @Composable
-private fun TrustChipsRow() {
-    val chipBg = if (isSystemInDarkTheme())
+private fun TrustChipsRow(dark: Boolean) {
+    val chipBg = if (dark)
         Color.White.copy(alpha = 0.24f)
     else
         MaterialTheme.colorScheme.surfaceVariant

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/MainActivity.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/MainActivity.kt
@@ -6,11 +6,16 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.view.WindowCompat
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.hilt.navigation.compose.hiltViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import com.hariomahlawat.bannedappdetector.ui.theme.BannedAppDetectorTheme
+import com.hariomahlawat.bannedappdetector.ThemeViewModel
+import com.hariomahlawat.bannedappdetector.ThemeSetting
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -19,15 +24,17 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
-            BannedAppDetectorTheme {
-                AppNavigation()
+            val vm: ThemeViewModel = hiltViewModel()
+            val theme by vm.theme.collectAsState()
+            BannedAppDetectorTheme(theme) {
+                AppNavigation(theme = theme, onToggleTheme = vm::toggleTheme)
             }
         }
     }
 }
 
 @Composable
-fun AppNavigation() {
+fun AppNavigation(theme: ThemeSetting, onToggleTheme: () -> Unit) {
     val navController = rememberNavController()
     NavHost(navController, startDestination = "splash") {
         composable("splash") {
@@ -40,7 +47,11 @@ fun AppNavigation() {
         composable("home") {
             HomeScreen(
                 onViewResults    = { navController.navigate("results") },
-                onViewBannedApps = { navController.navigate("bannedApps") }
+                onViewBannedApps = { navController.navigate("bannedApps") },
+                onToggleTheme    = onToggleTheme,
+                dark             = theme == ThemeSetting.DARK ||
+                                   (theme == ThemeSetting.SYSTEM &&
+                                    androidx.compose.foundation.isSystemInDarkTheme())
             )
         }
         composable("results") {

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/ThemeSetting.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/ThemeSetting.kt
@@ -1,0 +1,4 @@
+package com.hariomahlawat.bannedappdetector
+
+/** User theme preference. */
+enum class ThemeSetting { SYSTEM, LIGHT, DARK }

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/ThemeViewModel.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/ThemeViewModel.kt
@@ -1,0 +1,35 @@
+package com.hariomahlawat.bannedappdetector
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hariomahlawat.bannedappdetector.repository.ThemeRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ThemeViewModel @Inject constructor(
+    private val repo: ThemeRepository
+) : ViewModel() {
+
+    val theme: StateFlow<ThemeSetting> =
+        repo.themeFlow().stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = ThemeSetting.SYSTEM
+        )
+
+    fun toggleTheme() {
+        viewModelScope.launch {
+            val newSetting = when (theme.value) {
+                ThemeSetting.DARK -> ThemeSetting.LIGHT
+                ThemeSetting.LIGHT -> ThemeSetting.DARK
+                ThemeSetting.SYSTEM -> ThemeSetting.DARK
+            }
+            repo.setTheme(newSetting)
+        }
+    }
+}

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/data/di/AppModule.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/data/di/AppModule.kt
@@ -6,7 +6,9 @@ import android.content.pm.PackageManager
 import com.hariomahlawat.bannedappdetector.monitored.MonitoredAppsRepositoryImpl
 import com.hariomahlawat.bannedappdetector.repository.MonitoredAppsRepository
 import com.hariomahlawat.bannedappdetector.repository.ScanResultsRepository
+import com.hariomahlawat.bannedappdetector.repository.ThemeRepository
 import com.hariomahlawat.bannedappdetector.store.ScanResultsRepositoryImpl
+import com.hariomahlawat.bannedappdetector.store.ThemeRepositoryImpl
 import com.hariomahlawat.bannedappdetector.usecase.ComputeSummaryStatsUseCase
 import com.hariomahlawat.bannedappdetector.usecase.GetScanResultsFlowUseCase
 import com.hariomahlawat.bannedappdetector.usecase.ScanMonitoredAppsUseCase
@@ -42,6 +44,9 @@ object AppModule {
 
     @Provides @Singleton
     fun scanResultsRepo(impl: ScanResultsRepositoryImpl): ScanResultsRepository = impl
+
+    @Provides @Singleton
+    fun themeRepo(impl: ThemeRepositoryImpl): ThemeRepository = impl
 
     @Provides
     fun scanUseCase(

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/repository/Repositories.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/repository/Repositories.kt
@@ -3,6 +3,7 @@ package com.hariomahlawat.bannedappdetector.repository
 
 import com.hariomahlawat.bannedappdetector.MonitoredAppMeta
 import com.hariomahlawat.bannedappdetector.ScanResult
+import com.hariomahlawat.bannedappdetector.ThemeSetting
 import kotlinx.coroutines.flow.Flow
 
 interface MonitoredAppsRepository {
@@ -13,4 +14,10 @@ interface ScanResultsRepository {
     fun scanResultsFlow(): Flow<List<ScanResult>>
     suspend fun saveScanResults(results: List<ScanResult>)
     suspend fun latestResults(): List<ScanResult>
+}
+
+interface ThemeRepository {
+    fun themeFlow(): Flow<ThemeSetting>
+    suspend fun setTheme(theme: ThemeSetting)
+    suspend fun currentTheme(): ThemeSetting
 }

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/store/ThemeRepositoryImpl.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/store/ThemeRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package com.hariomahlawat.bannedappdetector.store
+
+import android.content.Context
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.hariomahlawat.bannedappdetector.ThemeSetting
+import com.hariomahlawat.bannedappdetector.repository.ThemeRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val DS_NAME = "user_prefs"
+private val Context.dataStore by preferencesDataStore(DS_NAME)
+private val KEY_THEME = stringPreferencesKey("theme")
+
+@Singleton
+class ThemeRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : ThemeRepository {
+
+    override fun themeFlow(): Flow<ThemeSetting> =
+        context.dataStore.data.map { prefs ->
+            prefs[KEY_THEME]?.let { ThemeSetting.valueOf(it) } ?: ThemeSetting.SYSTEM
+        }
+
+    override suspend fun setTheme(theme: ThemeSetting) {
+        context.dataStore.edit { it[KEY_THEME] = theme.name }
+    }
+
+    override suspend fun currentTheme(): ThemeSetting {
+        val prefs = context.dataStore.data.first()
+        return prefs[KEY_THEME]?.let { ThemeSetting.valueOf(it) } ?: ThemeSetting.SYSTEM
+    }
+}

--- a/app/src/main/java/com/hariomahlawat/bannedappdetector/ui/theme/Theme.kt
+++ b/app/src/main/java/com/hariomahlawat/bannedappdetector/ui/theme/Theme.kt
@@ -7,15 +7,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.foundation.isSystemInDarkTheme
+import com.hariomahlawat.bannedappdetector.ThemeSetting
 import com.hariomahlawat.bannedappdetector.ui.theme.AppTypography
 import com.hariomahlawat.bannedappdetector.ui.theme.BgGradientStart
 import com.hariomahlawat.bannedappdetector.ui.theme.BrandGold
 @Composable
 fun BannedAppDetectorTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    theme: ThemeSetting = ThemeSetting.SYSTEM,
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
+    val darkTheme = when (theme) {
+        ThemeSetting.SYSTEM -> isSystemInDarkTheme()
+        ThemeSetting.DARK   -> true
+        ThemeSetting.LIGHT  -> false
+    }
     val dynamic = if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
     val colorScheme = dynamic.copy(
         primary = BrandGold,


### PR DESCRIPTION
## Summary
- introduce `ThemeSetting` enum and data store `ThemeRepository`
- add `ThemeViewModel` with toggle action
- update Compose theme to use new setting
- wire theme toggle button in `HomeScreen`
- integrate with `MainActivity` navigation

## Testing
- `./gradlew assembleDebug` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_687f24744a8883298ad2b08d80216379